### PR TITLE
Bugfix fix datetime format for date hierachy sync

### DIFF
--- a/target_s3/sinks.py
+++ b/target_s3/sinks.py
@@ -49,7 +49,8 @@ class s3Sink(BatchSink):
         if folder_structure == "simple":
             s3_path = f"{path}/{self.stream_name}/{self.stream_name}.parquet"
         elif folder_structure == "date_hierarchy":
-            s3_path = f"{path}/{self.stream_name}/{NOW.year}/{NOW.month}/{NOW.day}/{self.stream_name}__{NOW.isoformat()}.parquet"
+            s3_path = f"{path}/{self.stream_name}/{NOW.year}/{NOW.month}/" \
+                      f"{NOW.day}/{self.stream_name}__{NOW.timestamp()}.parquet"
         else:
             raise ConfigValidationError(
                 'Invalid value for configuration key "folder_structure". Only values "simple" and "date_hierarchy" are supported.'


### PR DESCRIPTION
# Problem 
According to document from AWS S3, : character is not allow in filename https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html. 

# Solution
Change from isoformat() to timestamp()